### PR TITLE
Add BepInEx MaidVoicePitch soft dependency

### DIFF
--- a/ButtJiggle/ButtJiggle.cs
+++ b/ButtJiggle/ButtJiggle.cs
@@ -60,6 +60,7 @@ namespace COM3D2.ButtJiggle
 {
 	// This is the metadata set for your plugin.
 	[BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
+	[BepInDependency("COM3D2.MaidVoicePitch", BepInDependency.DependencyFlags.SoftDependency)]
 	public sealed partial class ButtJiggle : BaseUnityPlugin
 	{
 		// Static saving of the main instance. (Singleton design pattern)


### PR DESCRIPTION
Allows body morphs to be executed in the correct order.

With the UnityInjector version of MaidVoicePitch, patches "coincidentally" execute in the correct order, but with the BepInEx version, this dependency is required for certain hip sliders to work correctly.